### PR TITLE
`skip_on_error=True`

### DIFF
--- a/evaltools/source.py
+++ b/evaltools/source.py
@@ -139,6 +139,7 @@ def open_and_sort(
     dsets = catalog.to_dataset_dict(
         xarray_open_kwargs=xarray_open_kwargs,
         xarray_combine_by_coords_kwargs=xarray_combine_by_coords_kwargs,
+        skip_on_error=True,
     )
 
     for iid, ds in dsets.items():


### PR DESCRIPTION
Added `skip_on_error=True` to the `catalog.to_dataset_dict` function call to ensure that errors are skipped during dataset loading.